### PR TITLE
docs: repo polish — badges, issue/PR templates, SECURITY.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/adapter.yml
+++ b/.github/ISSUE_TEMPLATE/adapter.yml
@@ -1,0 +1,60 @@
+name: New adapter request
+description: Request support for a new AI coding-agent CLI.
+labels: ["adapter", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Adapters are ~80–120 line bash files implementing a 3-function contract.
+        See [docs/ADAPTERS.md](../../docs/ADAPTERS.md) — contributions welcome!
+
+  - type: input
+    id: harness-name
+    attributes:
+      label: Harness name
+      description: The CLI's name as users invoke it.
+      placeholder: claude-code, cursor-cli, codex, ...
+    validations:
+      required: true
+
+  - type: input
+    id: repo
+    attributes:
+      label: Upstream repo / homepage
+      placeholder: https://github.com/example/example
+    validations:
+      required: true
+
+  - type: textarea
+    id: storage
+    attributes:
+      label: How does this harness store sessions?
+      description: |
+        Filesystem path? SQLite DB? Per-project or global? Roughly how do you
+        list / delete a session today (CLI subcommand, manual `rm`)?
+      placeholder: |
+        - Storage: ~/.config/foo/sessions/<id>.json
+        - List: `foo session list --json`
+        - Delete: no official CLI; manual rm
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version installed locally
+      description: For testing/ fixture generation.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Are you willing to write the adapter?
+      options:
+        - label: I can submit a PR following docs/ADAPTERS.md
+          required: false
+        - label: I can provide schema + sample data, but I'd prefer someone else implements
+          required: false
+        - label: I'm just requesting it
+          required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Something is broken or behaves unexpectedly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The fastest way to get this
+        triaged is to fill in every box below.
+
+  - type: input
+    id: prune-version
+    attributes:
+      label: Prune version
+      description: Output of `prune --version`.
+      placeholder: prune 0.1.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: adapter
+    attributes:
+      label: Affected adapter
+      options:
+        - pi
+        - goose
+        - opencode
+        - forge
+        - core / dispatcher (not adapter-specific)
+        - install / uninstall script
+        - other
+    validations:
+      required: true
+
+  - type: input
+    id: harness-version
+    attributes:
+      label: Harness CLI version
+      description: Output of `<harness> --version` for the affected adapter (e.g., `goose --version`).
+      placeholder: goose 1.31.0
+    validations:
+      required: false
+
+  - type: input
+    id: os
+    attributes:
+      label: OS / shell
+      description: e.g. `Ubuntu 24.04 + zsh 5.9` or `macOS 14.4 arm64 + bash 5.2`.
+      placeholder: Ubuntu 24.04 + zsh 5.9
+    validations:
+      required: true
+
+  - type: textarea
+    id: doctor
+    attributes:
+      label: Output of `prune doctor`
+      description: Paste the full output. Redact paths if sensitive.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps to reproduce. Prefer `prune <harness> <mode> --dry-run` first.
+      placeholder: |
+        1. Run `prune goose --dry-run all`
+        2. ...
+        3. Expected X, got Y.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output / error
+      description: Stdout/stderr from the failing command. No need to be exhaustive.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest a new mode, flag, or behavior change.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: motivation
+    attributes:
+      label: What problem does this solve?
+      description: Describe the user need first, the proposed feature second.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: How should `prune` behave? Include the exact CLI surface (flags, modes) you'd add.
+      placeholder: |
+        Example: `prune <harness> --json` outputs the inventory as JSON instead
+        of the fzf picker, so users can pipe to `jq`.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - core (affects all adapters)
+        - one specific adapter
+        - install / uninstall
+        - docs only
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, or other tools that solve this differently.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+<!--
+Thanks for the PR. Fill in the sections below; remove any that don't apply.
+-->
+
+## Summary
+
+<!-- 1-3 sentences. What does this PR change and why? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature (no breaking change)
+- [ ] Breaking change
+- [ ] New adapter
+- [ ] Documentation only
+- [ ] Refactor / chore (no behavior change)
+
+## Adapter affected (if applicable)
+
+<!-- pi / goose / opencode / forge / core / install / docs -->
+
+## Tested against
+
+<!-- For adapter PRs: which version(s) of the upstream harness did you test? -->
+- [ ] Local: `<harness> --version` =
+- [ ] CI passes (shellcheck + tests)
+- [ ] Manual smoke: `prune <harness> --dry-run all` against real data
+
+## Checklist
+
+- [ ] `./tests/run.sh` passes locally
+- [ ] `shellcheck --severity=warning --shell=bash <changed-files>` passes
+- [ ] If adding an adapter: contract docs in `docs/ADAPTERS.md` are still accurate
+- [ ] If changing behavior: `CHANGELOG.md` updated under `[Unreleased]`
+
+## Notes / screenshots
+
+<!-- Optional. Useful for visual changes (paste an asciicast or GIF). -->

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 > Bulk-delete stored sessions from AI coding-agent CLIs — with the fzf picker
 > UX you'd actually use.
 
+[![CI](https://github.com/soyruiz/Prune/actions/workflows/ci.yml/badge.svg)](https://github.com/soyruiz/Prune/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Version](https://img.shields.io/github/v/release/soyruiz/Prune?include_prereleases&label=version)](https://github.com/soyruiz/Prune/releases)
+[![Shells](https://img.shields.io/badge/shell-bash%204%2B%20%7C%20zsh-informational)](#requirements)
+[![Adapters](https://img.shields.io/badge/adapters-pi%20%7C%20goose%20%7C%20opencode%20%7C%20forge-success)](docs/COMPATIBILITY.md)
+
 ![Prune demo](assets/demo.gif)
 
 `Prune` gives you one consistent way to wipe accumulated sessions across

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security policy
+
+## Supported versions
+
+Prune is in early development. Security fixes are applied to the latest
+released minor on `main`.
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x   | ✅ |
+| < 0.1.0 | ❌ (pre-release) |
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security-sensitive reports.
+
+Instead:
+
+1. Use GitHub's [private security advisory](https://github.com/soyruiz/Prune/security/advisories/new) flow, **or**
+2. Email the maintainer at the address listed on https://github.com/soyruiz.
+
+Include:
+- Affected version (`prune --version`).
+- Adapter affected, if any.
+- A reproduction or proof-of-concept (private to you and the maintainer).
+- Suggested mitigation, if you have one.
+
+You can expect:
+- An acknowledgement within 72 hours.
+- A fix or mitigation plan within 7 days for high-severity issues, longer for
+  lower-severity reports.
+- Public disclosure once a patch is released, with credit to the reporter
+  unless you prefer to remain anonymous.
+
+## Threat model
+
+Prune is a local CLI that:
+- Reads session metadata from harness-managed SQLite databases and JSONL
+  files.
+- Deletes sessions via either the upstream CLI or direct SQL.
+- Never sends data over the network and has no daemon component.
+
+Realistic risks Prune cares about:
+- **Path / SQL injection via session ids** — adapters validate ids against a
+  conservative `^[A-Za-z0-9_\-]+$` regex before interpolating into queries.
+- **Accidental data loss from running against the wrong DB** — the
+  `--dry-run` flag and the `prune doctor` pre-check exist for this.
+- **Race with a live harness writing to its DB** — out of scope for the CLI;
+  the README and AGENTS.md document the recommendation to quit the harness
+  TUI before a bulk delete.
+
+Out of scope:
+- Local code execution by an attacker who already has shell access (Prune is
+  bash; everything is observable in `bin/prune`).
+- Tampering with the upstream harness's binaries.


### PR DESCRIPTION
## Summary
Eleva el repo a "community-ready" con archivos que GitHub surface en sidebar y formularios:

- **README badges**: CI status, license, version (auto-fills tras la primera release), shells soportados, adapters soportados.
- **Issue templates** (`.github/ISSUE_TEMPLATE/{bug,feature,adapter}.yml` + `config.yml`): formularios estructurados con dropdowns para harness afectado, validación de campos críticos como output de `prune doctor`.
- **PR template**: checklist + tabla de "tested against" para cambios en adapters.
- **SECURITY.md**: flujo de reporte vía GitHub private security advisory + threat model corto. Activa el badge ✓ Security en el sidebar.

## Out of band (ya aplicado, no hace falta merge)
- 12 topics añadidos al repo: `cli`, `fzf`, `bash`, `zsh`, `ai-agents`, `goose`, `opencode`, `pi`, `developer-tools`, `terminal`, `shell-script`, `session-management`. Visibles en la card About.

## After merge
- Cortar release `v0.1.0` (la badge de versión se auto-popula).

## Why this is PR #2 (no #1 actualizado)
PR #1 se mergeó antes de que este commit llegara, así que recupero los cambios huérfanos en una rama nueva sobre `main`. El diff es solo el polish — ni el pixel title ni el GIF (esos ya están en main).

🤖 Generated with Claude Code